### PR TITLE
Feed the catalogue check to YAML as a block, which a ternary was spli…

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -42,7 +42,8 @@ jobs:
       # fetches it, and the failure is silent from the far end — the channel
       # falls back to its cache and says the origin was unreachable.
       - name: Check the catalogue parses
-        run: node -e "
+        run: |
+          node -e "
             const apps = require('./catalog/catalog.json');
             const list = Array.isArray(apps) ? apps : apps.apps;
             if (!Array.isArray(list)) throw new Error('catalog.json must be an array, or an object with an apps array.');


### PR DESCRIPTION
…tting

GitHub refused the workflow outright — "Invalid workflow file: .github/workflows/pages.yaml#L47, You have an error in your yaml syntax on line 47" — so the catalogue has not been publishing at all.

Line 47 is `const list = Array.isArray(apps) ? apps : apps.apps;` and there is nothing wrong with it. The fault is on line 45. `run: node -e "` looks like it opens a quoted string, but YAML only treats a quote as an indicator when it is the first character of the scalar, and the first character here is the `n` of `node`. So the whole step was a plain multi-line scalar, the `"` was an ordinary character, and plain scalars may not contain a colon followed by a space. The ternary is simply the first line that has one — any of the object literals below it would have done the same.

`run: |` makes the body literal, which is what it was always meant to be. The script is unchanged apart from its indentation.

Verified by extracting the step's `run:` and running it as the job would: exits 0, prints "0 apps", which is catalog/catalog.json's empty starting state rather than a check that quietly passes on nothing.