### PR TITLE
Make one log record one line, and stop show logs killing the app

### DIFF
--- a/service/src/main.js
+++ b/service/src/main.js
@@ -490,6 +490,27 @@ const start = () => {
 // refuses to ship a bundle without it.
 module.exports.onStart = start;
 module.exports.start = start;
+
+// `onRequest` is the other half of that same contract, and leaving it out was
+// not free. Tizen's service runner calls it for every app control request
+// delivered to a service that is *already* running — which is what the TV
+// page's launchAppControl does every time somebody opens the app, on the
+// second launch and every one after it. With nothing there to call, the runner
+// threw
+//
+//     TypeError: app.onRequest is not a function
+//         at MessagePort.<anonymous> (/usr/share/wrt/app/service/service_runner.js:152)
+//
+// into this process on every one of those launches. The service survived it —
+// the process-wide handler in obs/log.js catches it — but it wrote a stack
+// trace into the log each time, which is where it was eventually found:
+// somebody had opened the app to read the log.
+//
+// There is nothing to do with the request. The service is already listening,
+// and it carries nothing this one needs; saying so is the whole job. It is
+// logged at debug because the page writes its own line for the launch, and two
+// records for one event is how a log stops being read.
+module.exports.onRequest = () => log.on(Facility.SVC).debug('a launch reached a service that is already running');
 module.exports.BUILD = BUILD;
 module.exports.PORT = PORT;
 

--- a/service/src/obs/log.js
+++ b/service/src/obs/log.js
@@ -163,26 +163,49 @@ const startRecording = (options) => {
         }
     };
 
+    /**
+     * Writes a message to the ring, as one record per line of it.
+     *
+     * dmesg has no multi-line record and neither does this — the header at the
+     * top of this file promises that one record is one line, and every reader
+     * of this log is built on it. A stack trace arrives here as a single
+     * string with newlines in it, and it is the one thing that ever broke that
+     * promise.
+     *
+     * It broke it expensively. The television draws the log as a grid whose
+     * rows it counts to find how many fit, and a record eight lines tall made
+     * that count disagree with itself: nine rows fit when six were drawn, six
+     * fit when nine were. Pressing `show logs` recursed between the two until
+     * the stack ran out. See `fit` in ui/src/tv.js, which no longer trusts the
+     * count to settle either.
+     *
+     * Returns every record it wrote, because the caller prints them.
+     */
     const record = (level, facility, text) => {
-        if (level === 'debug' && !keepDebug) return null;
+        if (level === 'debug' && !keepDebug) return [];
 
-        const line = {
-            seq: ++sequence,
-            t: elapsed(),
-            at: new Date().toISOString(),
-            level,
-            facility,
-            text: text.length > MAX_LINE ? `${text.slice(0, MAX_LINE)}…` : text
-        };
+        // Trailing newlines are punctuation on the message rather than empty
+        // lines somebody meant to write; interior ones are kept, because a
+        // blank line in the middle of a stack trace is in the stack trace.
+        return String(text).replace(/[\r\n]+$/, '').split(/\r?\n/).map((one) => {
+            const line = {
+                seq: ++sequence,
+                t: elapsed(),
+                at: new Date().toISOString(),
+                level,
+                facility,
+                text: one.length > MAX_LINE ? `${one.slice(0, MAX_LINE)}…` : one
+            };
 
-        lines.push(line);
-        while (lines.length > max) lines.shift();
+            lines.push(line);
+            while (lines.length > max) lines.shift();
 
-        return line;
+            return line;
+        });
     };
 
     /**
-     * Writes one line, and prints it.
+     * Writes a message, and prints every line it became.
      *
      * Printing goes through the console function matching the severity, so the
      * platform's own log keeps the distinction too — on a TV that output is
@@ -190,16 +213,19 @@ const startRecording = (options) => {
      */
     const write = (level, facility, values) => {
         try {
-            const line = record(level, facility, values.map(render).join(' '));
-            if (!line) return;
-
-            if (settings.print) return settings.print(format(line), line);
+            const written = record(level, facility, values.map(render).join(' '));
 
             const print = level === 'err' ? SINK.pristine.error
                 : level === 'warn' ? SINK.pristine.warn
                 : SINK.pristine.log;
 
-            print.call(console, format(line));
+            // A message that became several records is printed as several
+            // lines, each stamped and named — so the platform's own log reads
+            // the way the television's does rather than keeping a shape this
+            // one has given up.
+            written.forEach((line) => (settings.print
+                ? settings.print(format(line), line)
+                : print.call(console, format(line))));
         } catch (e) {
             // Logging must never be the reason something fails.
         }

--- a/service/test/log.js
+++ b/service/test/log.js
@@ -62,6 +62,48 @@ const quietly = (options) => {
         bounded[bounded.length - 1].text);
 }
 
+// One record is one line, which is the promise the whole log is built on and
+// the one a stack trace used to break. The television counts log rows to find
+// how many fit on screen; a record eight lines tall made that count oscillate
+// and recursed the page until the stack ran out — pressing `show logs` killed
+// the app. See `fit` in ui/src/tv.js.
+{
+    const recorder = quietly({});
+
+    recorder.log.err(Facility.SVC, 'uncaught exception: TypeError: app.onRequest is not a function\n' +
+        '    at MessagePort.<anonymous> (/usr/share/wrt/app/service/service_runner.js:152:59)\n' +
+        '    at MessagePort.emit (events.js:310:20)');
+
+    const lines = recorder.since(0);
+
+    check('a stack trace becomes one record per line', lines.length === 3,
+        `kept ${lines.length}`);
+
+    check('and no record has a newline left in it',
+        lines.every((line) => line.text.indexOf('\n') === -1),
+        JSON.stringify(lines.map((line) => line.text)));
+
+    check('each line keeps the severity and facility of the message it came from',
+        lines.every((line) => line.level === 'err' && line.facility === Facility.SVC),
+        JSON.stringify(lines.map((line) => [line.facility, line.level])));
+
+    check('a poller can still resume from any of them',
+        recorder.since(lines[0].seq).length === 2, 'since(first) did not return the rest');
+
+    check('and every one of them is printed', recorder.printed.length === 3,
+        `printed ${recorder.printed.length}`);
+}
+
+// A message that simply ends in a newline is one line, not two: the newline is
+// punctuation on the message rather than an empty line somebody wrote.
+{
+    const recorder = quietly({});
+    recorder.log.info(Facility.SVC, 'coreinstall spend time = 1234 ms\n');
+
+    check('a trailing newline does not add an empty record', recorder.since(0).length === 1,
+        JSON.stringify(recorder.since(0).map((line) => line.text)));
+}
+
 // Debug is the level the TV page's own polling logs at: on by request only,
 // because recording it means every poll produces a line the next poll
 // delivers — a log that grows because it is being read.

--- a/service/test/pipeline.js
+++ b/service/test/pipeline.js
@@ -28,6 +28,13 @@ const realPackage = fixture.wgt();
     const entry = require('../src/main.js');
     check('the service exports onStart, which Tizen calls',
         typeof entry.onStart === 'function', `exports: ${Object.keys(entry).join(', ')}`);
+
+    // And onRequest, which Tizen calls for an app control request delivered to
+    // a service that is already running — every launch of the app after the
+    // first. Without it the runner threw `app.onRequest is not a function`
+    // into the service on each one, and the stack trace landed in the log.
+    check('and onRequest, which it calls on every launch after the first',
+        typeof entry.onRequest === 'function', `exports: ${Object.keys(entry).join(', ')}`);
 }
 
 // --- doubles -------------------------------------------------------------

--- a/ui/src/tv.js
+++ b/ui/src/tv.js
@@ -295,10 +295,34 @@ mount(store, { masthead, connect, status, log, overlay, deck });
  * the value goes into the store and the paint follows from there like
  * everything else.
  *
- * It settles immediately: the count changes what is drawn, the redraw is
- * measured again, and the second answer agrees with the first because there
- * are always spare rows below the fold to be cut off.
+ * With rows of one height it settles on the second pass: the count changes
+ * what is drawn, the redraw is measured again, and the second answer agrees
+ * with the first because there are always spare rows below the fold to be cut
+ * off. It is not allowed to *depend* on that, and `offered` below is why.
  */
+
+// Every count this settle has already asked for, and whether the repaint now
+// being measured is one this measurement caused.
+//
+// Measuring the pane and then redrawing it changes what there is to measure,
+// so this is a fixed-point iteration — and a fixed point is not guaranteed.
+// Rows are only the same height while every line is one line long: a service
+// record carrying a stack trace was eight, and the sequence became a cycle
+// rather than converging. Nine rows fitted when six were drawn, six fitted
+// when nine were, and neither answer was wrong.
+//
+// Each pass is a synchronous repaint through the store, so a cycle is not a
+// flicker — it is this page recursing until the stack ends. On a television
+// that killed the app, and pressing `show logs` was how you did it.
+//
+// So a settle is bounded. Every answer is remembered, and the moment one
+// repeats — which is the cycle, announcing itself — the smallest is taken and
+// the pass ends. The smallest is the safe end of a cycle: it is the count that
+// fits whichever rows are on screen, where the largest overflows the pane it
+// was measured against.
+let offered = [];
+let settling = false;
+
 const fit = () => {
     const pane = document.querySelector('.curtain .feed, .curtain .roll');
     if (!pane) return;
@@ -321,7 +345,29 @@ const fit = () => {
         })
         .length;
 
-    if (rows > 0 && rows !== store.get().rows) store.update({ rows });
+    if (rows === 0 || rows === store.get().rows) return;
+
+    const settle = (count) => {
+        offered.push(count);
+        settling = true;
+
+        try {
+            store.update({ rows: count });
+        } finally {
+            settling = false;
+        }
+    };
+
+    if (offered.indexOf(rows) === -1) return settle(rows);
+
+    const smallest = Math.min.apply(null, offered);
+    if (smallest !== store.get().rows) settle(smallest);
+};
+
+/** A settle that starts over, for a pane this measurement did not cause. */
+const remeasure = () => {
+    offered = [];
+    fit();
 };
 
 // The deck is replaced wholesale on every repaint, so the element holding
@@ -329,14 +375,17 @@ const fit = () => {
 // light back on it — by name, which is why it survives the swap.
 store.subscribe(() => {
     keys.restore();
-    fit();
+
+    // A change from anywhere else — a log line, an overlay opening — is a new
+    // pane, and the counts offered against the last one say nothing about it.
+    if (settling) fit(); else remeasure();
 });
 
 keys.focus('theme');
 
 // Off a television the window is resizable, which is the only thing that
 // changes how much fits without the state changing first.
-window.addEventListener('resize', fit);
+window.addEventListener('resize', remeasure);
 
 // ── Reading the service's log ─────────────────────────────────────────
 


### PR DESCRIPTION
Pressing `show logs` on the television killed the app. What was on screen when it did was a stack trace, which is how it was reported and which turned out to be the cause rather than the coincidence it looked like.

Two defects, and the first one arms the second.

main.js exported onStart and nothing else. Tizen's service runner also calls onRequest, for an app control request delivered to a service that is *already* running — which is what the page's launchAppControl does on the second launch of the app and every one after it. With nothing there to call, the runner threw

    TypeError: app.onRequest is not a function
        at MessagePort.<anonymous> (/usr/share/wrt/app/service/service_runner.js:152:59)
        at MessagePort.emit (events.js:310:20)
        at MessagePort.onmessage (internal/worker/io.js:78:8)
        at MessagePort.exports.emitMessage (internal/per_context/messageport.js:11:10)

into the service on every one of those launches. The service survived it — the process-wide handler in obs/log.js catches it — so it only ever showed up as four stack traces in the log, which is where it was found. The set had logged one per launch for as long as the app had been opened twice.

Then the log took that trace and kept it as a single record with newlines in it. The header of obs/log.js promises that one record is dmesg's line, and every reader of this log is built on that promise; this was the one thing that ever broke it. The console draws the log as a grid and counts the rows that fit to find how many there is room for, and a record eight lines tall made the count disagree with itself. Nine rows fitted when six were drawn, six fitted when nine were, and neither answer was wrong. Each pass is a synchronous repaint through the store, so the two chased each other down the stack:

    rows drawn per repaint: [17, 10, 6, 9, 6, 9, 6, 9, 6, 9, ...]
    total repaints of the log overlay: 3319
    RangeError: Maximum call stack size exceeded

Measured against the television's own log, replayed into ui/dist/tv.html at 1920x1080. Desktop Chromium survives that and throws; Chromium 63 on a set does not, and the app goes away.

So record() splits on newlines and writes one record per line, and write() prints each of them — the platform's log now reads the way the screen does rather than keeping a shape this one has given up. A stack trace is eight rows you can scroll a line at a time instead of one row the direction keys step over whole.

And fit() no longer trusts the count to settle. It remembers every count a settle has offered, and the moment one repeats — which is the cycle, announcing itself — it takes the smallest and stops. The smallest is the safe end: it is the count that fits whichever rows are on screen, where the largest overflows the pane it was measured against. This is not only a guard against the record above. Rows are the same height while every line is one line long, and a long enough message still wraps.

The same log, after: two repaints to settle, sixteen rows, no gap under the last one, no exceptions. Scrolling, paging, RED-to-newest and back all behave, and focus lands on the button that opened it.

Installed and running on the television this was diagnosed against.